### PR TITLE
Add dedicated Claude Code role using official installer

### DIFF
--- a/roles/claude-code/defaults/main.yaml
+++ b/roles/claude-code/defaults/main.yaml
@@ -1,0 +1,3 @@
+---
+CLAUDE_TEMP_DIR: "/tmp/{{playbook_dir|basename}}/ansible.roles/{{role_name}}"
+

--- a/roles/claude-code/files/claude-code.sh
+++ b/roles/claude-code/files/claude-code.sh
@@ -1,0 +1,4 @@
+case ":$PATH:" in
+  *":$HOME/.local/bin:"*) ;;
+  *) export PATH="$HOME/.local/bin:$PATH" ;;
+esac

--- a/roles/claude-code/meta/main.yaml
+++ b/roles/claude-code/meta/main.yaml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - role: shell-env

--- a/roles/claude-code/tasks/main.yaml
+++ b/roles/claude-code/tasks/main.yaml
@@ -1,0 +1,24 @@
+---
+- name: "Create {{CLAUDE_TEMP_DIR}}"
+  ansible.builtin.file:
+    path: "{{CLAUDE_TEMP_DIR}}"
+    state: directory
+
+- name: "Download claude-code installer"
+  ansible.builtin.get_url:
+    url: https://claude.ai/install.sh
+    dest: "{{CLAUDE_TEMP_DIR}}"
+  register: CLAUDE_INSTALLER
+
+- name: "Install claude-code"
+  ansible.builtin.script: |
+    {{ CLAUDE_INSTALLER.dest }}
+  when: CLAUDE_INSTALLER.changed
+
+- name: "Config Shell Env"
+  ansible.builtin.blockinfile:
+    path: "{{SHARED_ENV_SH.dest}}"
+    create: yes
+    marker: "#### {mark} ANSIBLE MANAGED BLOCK - {{playbook_dir|basename}}/roles/{{role_name}} ####"
+    block: source {{role_path}}/files/claude-code.sh
+

--- a/roles/node/defaults/main.yaml
+++ b/roles/node/defaults/main.yaml
@@ -1,7 +1,6 @@
 ---
 NODE_PACKAGES:
   - bash-language-server
-  - "@anthropic-ai/claude-code"
   - neovim
   - vim-language-server
   - vscode-langservers-extracted


### PR DESCRIPTION
## Summary
- Add new `claude-code` Ansible role that installs Claude Code using the official installer from claude.ai
- Remove `@anthropic-ai/claude-code` from npm packages in the node role
- Configure shell PATH via blockinfile for proper CLI access

## Test plan
- [ ] Run playbook and verify Claude Code is installed correctly
- [ ] Verify `claude` command is available in new shell sessions