### PR TITLE
Use ansible_facts dictionary instead of top-level fact variables

### DIFF
--- a/roles/1password/tasks/main.yaml
+++ b/roles/1password/tasks/main.yaml
@@ -1,4 +1,4 @@
 ---
-- name: "Setup For {{ansible_system}}"
-  ansible.builtin.include_tasks: "{{ansible_os_family|lower}}.yaml"
+- name: "Setup For {{ansible_facts['system']}}"
+  ansible.builtin.include_tasks: "{{ansible_facts['os_family']|lower}}.yaml"
 

--- a/roles/base/tasks/darwin.yaml
+++ b/roles/base/tasks/darwin.yaml
@@ -15,7 +15,7 @@
     state: latest
     name: "{{HOMEBREW_CASK_PACKAGES}}"
 
-- name: "Install {{ansible_distribution}} Packages"
+- name: "Install {{ansible_facts['distribution']}} Packages"
   ansible.builtin.package:
     state: latest
     name: "{{HOMEBREW_PACKAGES}}"

--- a/roles/base/tasks/distros/debian.yaml
+++ b/roles/base/tasks/distros/debian.yaml
@@ -1,5 +1,5 @@
 ---
-- name: Install {{ansible_distribution}} Packages
+- name: Install {{ansible_facts['distribution']}} Packages
   become: yes
   ansible.builtin.package:
     state: latest

--- a/roles/base/tasks/distros/fedora.yaml
+++ b/roles/base/tasks/distros/fedora.yaml
@@ -1,5 +1,5 @@
 ---
-- name: Install {{ansible_distribution}} Packages
+- name: Install {{ansible_facts['distribution']}} Packages
   become: yes
   ansible.builtin.package:
     state: latest

--- a/roles/base/tasks/linux.yaml
+++ b/roles/base/tasks/linux.yaml
@@ -13,7 +13,7 @@
     state: latest
     name: "{{REQUIRED_PACKAGES['common'] + OPTIONAL_PACKAGES['common']}}"
 
-- name: Install {{ansible_distribution}} Packages
+- name: Install {{ansible_facts['distribution']}} Packages
   ansible.builtin.include_tasks:
-    file: "distros/{{ansible_distribution|lower}}.yaml"
+    file: "distros/{{ansible_facts['distribution']|lower}}.yaml"
 

--- a/roles/base/tasks/main.yaml
+++ b/roles/base/tasks/main.yaml
@@ -1,7 +1,7 @@
 ---
-- name: Include {{ansible_system}} Variables
-  ansible.builtin.include_vars: "{{ansible_system|lower}}.yaml"
+- name: Include {{ansible_facts['system']}} Variables
+  ansible.builtin.include_vars: "{{ansible_facts['system']|lower}}.yaml"
 
-- name: Install {{ansible_system}} Packages
-  ansible.builtin.include_tasks: "{{ansible_system|lower}}.yaml"
+- name: Install {{ansible_facts['system']}} Packages
+  ansible.builtin.include_tasks: "{{ansible_facts['system']|lower}}.yaml"
 

--- a/roles/chatgpt/tasks/main.yaml
+++ b/roles/chatgpt/tasks/main.yaml
@@ -3,5 +3,5 @@
   community.general.homebrew_cask:
     state: latest
     name: chatgpt
-  when: ansible_os_family|lower == "darwin"
+  when: ansible_facts['os_family']|lower == "darwin"
 

--- a/roles/colorscheme/tasks/gnome-terminal.yaml
+++ b/roles/colorscheme/tasks/gnome-terminal.yaml
@@ -2,13 +2,13 @@
 - name: "Git Clone arcticicestudio/nord-gnome-terminal"
   ansible.builtin.git:
     repo: https://github.com/arcticicestudio/nord-gnome-terminal.git
-    dest: "{{ansible_env.HOME}}/.nord-gnome-terminal"
+    dest: "{{ansible_facts['env'].HOME}}/.nord-gnome-terminal"
   register: NORD_GNOME_TERMINAL_REPO
 
 - name: "Install Nord Color Scheme For Gnome Terminal"
   ansible.builtin.shell:
     cmd: "dbus-run-session ./nord.sh"
-    chdir: "{{ansible_env.HOME}}/.nord-gnome-terminal/src"
+    chdir: "{{ansible_facts['env'].HOME}}/.nord-gnome-terminal/src"
   when: NORD_GNOME_TERMINAL_REPO.changed
 
 - name: "List Gnome Terminal Profile Ids"

--- a/roles/colorscheme/tasks/iterm2-app.yaml
+++ b/roles/colorscheme/tasks/iterm2-app.yaml
@@ -2,11 +2,11 @@
 - name: "Git Clone arcticicestudio/nord-iterm2"
   ansible.builtin.git:
     repo: https://github.com/arcticicestudio/nord-iterm2.git
-    dest: "{{ansible_env.HOME}}/.nord-iterm2"
+    dest: "{{ansible_facts['env'].HOME}}/.nord-iterm2"
   register: NORD_ITERM2_REPO
 
 - name: "Install Nord Color Scheme For iterm2"
   ansible.builtin.shell:
-    cmd: "open {{ansible_env.HOME}}/.nord-iterm2/src/xml/Nord.itermcolors"
+    cmd: "open {{ansible_facts['env'].HOME}}/.nord-iterm2/src/xml/Nord.itermcolors"
   when: NORD_ITERM2_REPO.changed
 

--- a/roles/colorscheme/tasks/main.yaml
+++ b/roles/colorscheme/tasks/main.yaml
@@ -1,4 +1,4 @@
 ---
-- name: "Set Color Scheme For {{ansible_system}}"
-  ansible.builtin.include_tasks: "{{TERMINALS[ansible_system|lower]}}.yaml"
+- name: "Set Color Scheme For {{ansible_facts['system']}}"
+  ansible.builtin.include_tasks: "{{TERMINALS[ansible_facts['system']|lower]}}.yaml"
 

--- a/roles/dbus-daemon/tasks/main.yaml
+++ b/roles/dbus-daemon/tasks/main.yaml
@@ -4,5 +4,5 @@
   ansible.builtin.package:
     state: latest
     name: dbus-daemon
-  when: ansible_system|lower == "linux"
+  when: ansible_facts['system']|lower == "linux"
 

--- a/roles/dconf/tasks/main.yaml
+++ b/roles/dconf/tasks/main.yaml
@@ -1,5 +1,5 @@
 ---
 - name: Install dconf
-  ansible.builtin.include_tasks: "{{ansible_os_family|lower}}.yaml"
-  when: ansible_system|lower == "linux"
+  ansible.builtin.include_tasks: "{{ansible_facts['os_family']|lower}}.yaml"
+  when: ansible_facts['system']|lower == "linux"
 

--- a/roles/gitconfig/tasks/main.yaml
+++ b/roles/gitconfig/tasks/main.yaml
@@ -23,9 +23,9 @@
   community.general.git_config:
     scope: global
     name: user.signingkey
-    value: "{{ansible_env.GIT_USER_SIGNINGKEY}}"
+    value: "{{ansible_facts['env'].GIT_USER_SIGNINGKEY}}"
     state: present
   when:
     - signingkey.config_value|length == 0
-    - ansible_env.GIT_USER_SIGNINGKEY is defined
+    - ansible_facts['env'].GIT_USER_SIGNINGKEY is defined
 

--- a/roles/gnupg/tasks/darwin.yaml
+++ b/roles/gnupg/tasks/darwin.yaml
@@ -1,7 +1,7 @@
 ---
 - name: "Set pinentry-program"
   ansible.builtin.blockinfile:
-    path: "{{ansible_env.HOME}}/.gnupg/gpg-agent.conf"
+    path: "{{ansible_facts['env'].HOME}}/.gnupg/gpg-agent.conf"
     create: yes
     marker: "#### {mark} ANSIBLE MANAGED BLOCK - {{playbook_dir|basename}}/roles/{{role_name}} ####"
     block: pinentry-program /opt/homebrew/bin/pinentry-mac

--- a/roles/gnupg/tasks/main.yaml
+++ b/roles/gnupg/tasks/main.yaml
@@ -11,6 +11,6 @@
     marker: "#### {mark} ANSIBLE MANAGED BLOCK - {{playbook_dir|basename}}/roles/{{role_name}} ####"
     block: export GPG_TTY=$(tty)
 
-- name: "Setup For {{ansible_system}}"
-  ansible.builtin.include_tasks: "{{ansible_system|lower}}.yaml"
+- name: "Setup For {{ansible_facts['system']}}"
+  ansible.builtin.include_tasks: "{{ansible_facts['system']|lower}}.yaml"
 

--- a/roles/homebrew-dependencies/tasks/debian.yaml
+++ b/roles/homebrew-dependencies/tasks/debian.yaml
@@ -1,6 +1,6 @@
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/ansible/ansible-lint/refs/heads/main/src/ansiblelint/schemas/tasks.json 
-- name: Install {{ansible_distribution}} Packages
+- name: Install {{ansible_facts['distribution']}} Packages
   become: true
   ansible.builtin.apt:
     state: latest

--- a/roles/homebrew-dependencies/tasks/fedora.yaml
+++ b/roles/homebrew-dependencies/tasks/fedora.yaml
@@ -1,6 +1,6 @@
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/ansible/ansible-lint/refs/heads/main/src/ansiblelint/schemas/tasks.json 
-- name: Install {{ansible_distribution}} Packages
+- name: Install {{ansible_facts['distribution']}} Packages
   become: true
   ansible.builtin.dnf:
     state: latest

--- a/roles/homebrew-dependencies/tasks/main.yaml
+++ b/roles/homebrew-dependencies/tasks/main.yaml
@@ -1,6 +1,6 @@
 ---
-- name: Install {{ansible_distribution}} Packages
+- name: Install {{ansible_facts['distribution']}} Packages
   ansible.builtin.include_tasks:
-    file: "{{ansible_distribution|lower}}.yaml"
+    file: "{{ansible_facts['distribution']|lower}}.yaml"
 
 

--- a/roles/intellij/defaults/main.yaml
+++ b/roles/intellij/defaults/main.yaml
@@ -2,8 +2,8 @@
 IDEA_TEMP_DIR: "/tmp/{{playbook_dir|basename}}/ansible.roles/{{role_name}}"
 
 IDEA_PLUGINS_BASE_DIR:
-  linux: "{{ansible_env.HOME}}/.local/share/JetBrains"
-  darwin: "{{ansible_env.HOME}}/Library/Application Support/JetBrains"
+  linux: "{{ansible_facts['env'].HOME}}/.local/share/JetBrains"
+  darwin: "{{ansible_facts['env'].HOME}}/Library/Application Support/JetBrains"
 
 IDEA_PLUGINS_DIR:
   linux: "{{IDEA_PLUGINS_BASE_DIR['linux']}}/IdeaIC{{IDEA_VERSION.split('.')[:2]|join('.')}}"

--- a/roles/intellij/tasks/linux.yaml
+++ b/roles/intellij/tasks/linux.yaml
@@ -1,6 +1,6 @@
 ---
-- name: Include {{ansible_system}} Variables
-  ansible.builtin.include_vars: "{{ansible_system|lower}}.yaml"
+- name: Include {{ansible_facts['system']}} Variables
+  ansible.builtin.include_vars: "{{ansible_facts['system']|lower}}.yaml"
 
 - name: "Get intellij-idea-ce Version"
   ansible.builtin.shell:

--- a/roles/intellij/tasks/main.yaml
+++ b/roles/intellij/tasks/main.yaml
@@ -5,11 +5,11 @@
     state: directory
 
 - name: Install IntelliJ IDEA CE
-  ansible.builtin.include_tasks: "{{ansible_system|lower}}.yaml"
+  ansible.builtin.include_tasks: "{{ansible_facts['system']|lower}}.yaml"
 
 - name: "Create IntelliJ IDEA CE Plugins Directory"
   ansible.builtin.file:
-    path: "{{IDEA_PLUGINS_DIR[ansible_system|lower]}}"
+    path: "{{IDEA_PLUGINS_DIR[ansible_facts['system']|lower]}}"
     state: directory
     mode: "0775"
   register: IDEA_CURRENT_PLUGINS_DIR

--- a/roles/libglib2.0-bin/tasks/main.yaml
+++ b/roles/libglib2.0-bin/tasks/main.yaml
@@ -6,5 +6,5 @@
     autoremove: true
     install_recommends: false
     name: libglib2.0-bin
-  when: ansible_os_family|lower == "debian"
+  when: ansible_facts['os_family']|lower == "debian"
 

--- a/roles/neovim/defaults/main.yaml
+++ b/roles/neovim/defaults/main.yaml
@@ -1,4 +1,4 @@
 ---
-NEOVIM_CONFIG_DIR: "{{ansible_env.HOME}}/.config/nvim"
-NEOVIM_AUTOLOAD_DIR: "{{ansible_env.HOME}}/.local/share/nvim/site/autoload"
+NEOVIM_CONFIG_DIR: "{{ansible_facts['env'].HOME}}/.config/nvim"
+NEOVIM_AUTOLOAD_DIR: "{{ansible_facts['env'].HOME}}/.local/share/nvim/site/autoload"
 

--- a/roles/neovim/tasks/main.yaml
+++ b/roles/neovim/tasks/main.yaml
@@ -21,7 +21,7 @@
 - name: "Git Clone junegunn/vim-plug"
   ansible.builtin.git:
     repo: https://github.com/junegunn/vim-plug
-    dest: "{{ansible_env.HOME}}/.vim-plug"
+    dest: "{{ansible_facts['env'].HOME}}/.vim-plug"
 
 - name: "Create NeoVim autoload Dir"
   ansible.builtin.file:
@@ -30,7 +30,7 @@
 
 - name: "Symlink plug.vim To autoload Dir"
   ansible.builtin.file:
-    src: "{{ansible_env.HOME}}/.vim-plug/plug.vim"
+    src: "{{ansible_facts['env'].HOME}}/.vim-plug/plug.vim"
     path: "{{NEOVIM_AUTOLOAD_DIR}}/plug.vim"
     state: link
 

--- a/roles/nerdfonts/tasks/gnome-terminal.yaml
+++ b/roles/nerdfonts/tasks/gnome-terminal.yaml
@@ -1,6 +1,6 @@
 ---
-- name: Include {{TERMINALS[ansible_system|lower]}} Variables
-  ansible.builtin.include_vars: "{{TERMINALS[ansible_system|lower]}}.yaml"
+- name: Include {{TERMINALS[ansible_facts['system']|lower]}} Variables
+  ansible.builtin.include_vars: "{{TERMINALS[ansible_facts['system']|lower]}}.yaml"
 
 - name: "Find Default Profile"
   ansible.builtin.shell:

--- a/roles/nerdfonts/tasks/main.yaml
+++ b/roles/nerdfonts/tasks/main.yaml
@@ -1,38 +1,38 @@
 ---
 - name: "Check previous checkout"
   ansible.builtin.stat:
-    path: "{{ansible_env.HOME}}/.nerd-fonts"
+    path: "{{ansible_facts['env'].HOME}}/.nerd-fonts"
   register: NERD_FONTS_DIR
 
 - name: "Sparse Checkout ryanoasis/nerd-fonts"
   ansible.builtin.shell:
     cmd: git clone --filter=blob:none --sparse https://github.com/ryanoasis/nerd-fonts .nerd-fonts
-    chdir: "{{ansible_env.HOME}}"
+    chdir: "{{ansible_facts['env'].HOME}}"
   when: not NERD_FONTS_DIR.stat.exists
 
 - name: "Check {{FONT.DIR}}"
   ansible.builtin.stat:
-    path: "{{ansible_env.HOME}}/.nerd-fonts/{{FONT.DIR}}"
+    path: "{{ansible_facts['env'].HOME}}/.nerd-fonts/{{FONT.DIR}}"
   register: NERD_FONTS_FONT_DIR
 
 - name: "Sparse Checkout {{FONT.DIR}}"
   ansible.builtin.shell:
     cmd: git sparse-checkout add {{FONT.DIR}}
-    chdir: "{{ansible_env.HOME}}/.nerd-fonts"
+    chdir: "{{ansible_facts['env'].HOME}}/.nerd-fonts"
   when: not NERD_FONTS_FONT_DIR.stat.exists
 
 - name: "Git Pull ryanoasis/nerd-fonts"
   ansible.builtin.git:
     repo: https://github.com/ryanoasis/nerd-fonts.git
-    dest: "{{ansible_env.HOME}}/.nerd-fonts"
+    dest: "{{ansible_facts['env'].HOME}}/.nerd-fonts"
   register: NERD_FONTS_REPO
 
 - name: ".nerd-fonts/install.sh --clean --quiet"
   ansible.builtin.shell:
     cmd: git pull && ./install.sh --clean --quiet
-    chdir: "{{ansible_env.HOME}}/.nerd-fonts"
+    chdir: "{{ansible_facts['env'].HOME}}/.nerd-fonts"
   when: NERD_FONTS_REPO.changed
 
-- name: "Set Font For {{ansible_system}}"
-  ansible.builtin.include_tasks: "{{TERMINALS[ansible_system|lower]}}.yaml"
+- name: "Set Font For {{ansible_facts['system']}}"
+  ansible.builtin.include_tasks: "{{TERMINALS[ansible_facts['system']|lower]}}.yaml"
 

--- a/roles/ohmyzsh/tasks/main.yaml
+++ b/roles/ohmyzsh/tasks/main.yaml
@@ -2,12 +2,12 @@
 - name: "Git Clone ohmyzsh/ohmyzsh"
   ansible.builtin.git:
     repo: https://github.com/ohmyzsh/ohmyzsh.git
-    dest: "{{ansible_env.HOME}}/.oh-my-zsh"
+    dest: "{{ansible_facts['env'].HOME}}/.oh-my-zsh"
   register: OMZ_REPO
 
 - name: "Copy zshrc.zsh-template to {{playbook_dir}}/.generated/oh-my-zsh.zshrc"
   ansible.builtin.copy:
-    src: "{{ansible_env.HOME}}/.oh-my-zsh/templates/zshrc.zsh-template"
+    src: "{{ansible_facts['env'].HOME}}/.oh-my-zsh/templates/zshrc.zsh-template"
     dest: "{{playbook_dir}}/.generated/oh-my-zsh.zshrc"
     remote_src: yes
   when: OMZ_REPO.changed
@@ -49,11 +49,11 @@
 - name: "Git Clone romkatv/powerlevel10k"
   ansible.builtin.git:
     repo: https://github.com/romkatv/powerlevel10k.git
-    dest: "{{ansible_env.HOME}}/.oh-my-zsh/custom/themes/powerlevel10k"
+    dest: "{{ansible_facts['env'].HOME}}/.oh-my-zsh/custom/themes/powerlevel10k"
 
-- name: "Symlink p10k.zsh to {{ansible_env.HOME}}/.p10k.zsh"
+- name: "Symlink p10k.zsh to {{ansible_facts['env'].HOME}}/.p10k.zsh"
   ansible.builtin.file:
-    path: "{{ansible_env.HOME}}/.p10k.zsh"
+    path: "{{ansible_facts['env'].HOME}}/.p10k.zsh"
     src: "{{role_path}}/files/p10k.zsh"
     state: link
   register: P10K_ZSH

--- a/roles/podman/tasks/main.yaml
+++ b/roles/podman/tasks/main.yaml
@@ -1,6 +1,6 @@
 ---
 - name: "podman"
-  ansible.builtin.include_tasks: "{{ansible_system|lower}}.yaml"
+  ansible.builtin.include_tasks: "{{ansible_facts['system']|lower}}.yaml"
 
 - name: "podman-compose"
   community.general.homebrew:

--- a/roles/shell-env/tasks/bash.yaml
+++ b/roles/shell-env/tasks/bash.yaml
@@ -15,7 +15,7 @@
 
 - name: "Add To User Shell Env"
   ansible.builtin.blockinfile:
-    path: "{{ansible_env.HOME}}/.bashrc"
+    path: "{{ansible_facts['env'].HOME}}/.bashrc"
     marker: "#### {mark} ANSIBLE MANAGED BLOCK - {{playbook_dir|basename}}/roles/{{role_name}} ####"
     block: source {{BASH_ENV_SH.dest}}
     create: true

--- a/roles/shell-env/tasks/zsh.yaml
+++ b/roles/shell-env/tasks/zsh.yaml
@@ -15,7 +15,7 @@
 
 - name: "Add To User Shell Env"
   ansible.builtin.blockinfile:
-    path: "{{ansible_env.HOME}}/.zshrc"
+    path: "{{ansible_facts['env'].HOME}}/.zshrc"
     marker: "#### {mark} ANSIBLE MANAGED BLOCK - {{playbook_dir|basename}}/roles/{{role_name}} ####"
     block: source {{ZSH_ENV_SH.dest}}
     create: true

--- a/roles/terminal-app/tasks/main.yaml
+++ b/roles/terminal-app/tasks/main.yaml
@@ -1,4 +1,4 @@
 ---
 - name: Install terminal app
-  ansible.builtin.include_tasks: "{{ansible_system|lower}}.yaml"
+  ansible.builtin.include_tasks: "{{ansible_facts['system']|lower}}.yaml"
 

--- a/roles/tmux/defaults/main.yaml
+++ b/roles/tmux/defaults/main.yaml
@@ -1,3 +1,3 @@
 ---
-TMUX_PLUGIN_DIR: "{{ansible_env.HOME}}/.tmux/plugins"
+TMUX_PLUGIN_DIR: "{{ansible_facts['env'].HOME}}/.tmux/plugins"
 

--- a/roles/tmux/tasks/main.yaml
+++ b/roles/tmux/tasks/main.yaml
@@ -17,12 +17,12 @@
 
 - name: "Git Clone tmux-plugins/tpm"
   ansible.builtin.blockinfile:
-    path: "{{ansible_env.HOME}}/.tmux.conf"
+    path: "{{ansible_facts['env'].HOME}}/.tmux.conf"
     create: yes
     marker: "#### {mark} ANSIBLE MANAGED BLOCK - {{playbook_dir|basename}}/roles/{{role_name}} ####"
     block: source-file "{{role_path}}/files/tmux.conf"
 
 - ansible.builtin.shell:
-    cmd: "{{ansible_env.HOME}}/.tmux/plugins/tpm/bin/install_plugins"
+    cmd: "{{ansible_facts['env'].HOME}}/.tmux/plugins/tpm/bin/install_plugins"
   changed_when: false
 

--- a/roles/uuid-runtime/tasks/main.yaml
+++ b/roles/uuid-runtime/tasks/main.yaml
@@ -6,5 +6,5 @@
     autoremove: true
     install_recommends: false
     name: uuid-runtime
-  when: ansible_os_family|lower == "debian"
+  when: ansible_facts['os_family']|lower == "debian"
 


### PR DESCRIPTION
## Summary
- Replace deprecated top-level fact variables with `ansible_facts` dictionary
- Fixes `INJECT_FACTS_AS_VARS` deprecation warning
- Prepares codebase for ansible-core 2.24

## Changes
- `ansible_system` -> `ansible_facts['system']`
- `ansible_os_family` -> `ansible_facts['os_family']`
- `ansible_distribution` -> `ansible_facts['distribution']`
- `ansible_env` -> `ansible_facts['env']`

## Test plan
- [ ] Run playbook and verify no deprecation warnings
- [ ] Verify all roles function correctly with new syntax