### PR TITLE
Skip Rosetta installation if already installed

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -41,11 +41,11 @@ setup-Darwin() {
 }
 
 setup-rosetta() {
-  if [[ $(uname -m) == "arm64" ]]; then
+  if [[ $(uname -m) == "arm64" ]] && [[ ! -f /Library/Apple/usr/share/rosetta/rosetta ]]; then
     echo "Installing Rosetta for Apple silicon"
     softwareupdate --install-rosetta --agree-to-license
   else
-    echo "No need for Rosetta"
+    echo "Rosetta not needed or already installed"
   fi
 }
 


### PR DESCRIPTION
## Summary
- Check for existing Rosetta binary before attempting installation
- Avoids unnecessary `softwareupdate` calls on subsequent runs

## Test plan
- [ ] Run setup.sh on Apple Silicon Mac with Rosetta already installed
- [ ] Verify "Rosetta not needed or already installed" message appears