### PR TITLE
Replace Dependabot with Renovate

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "daily"

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": ["^roles/rbenv/defaults/main\\.yaml$"],
+      "matchStrings": ["RUBY_VERSIONS:\\s*\\n\\s*- (?<currentValue>[0-9]+\\.[0-9]+\\.[0-9]+)"],
+      "depNameTemplate": "ruby",
+      "datasourceTemplate": "ruby-version"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": ["^roles/pyenv/defaults/main\\.yaml$"],
+      "matchStrings": ["PYTHON_VERSIONS:\\s*\\n\\s*- (?<currentValue>[0-9]+\\.[0-9]+\\.[0-9]+)"],
+      "depNameTemplate": "python",
+      "datasourceTemplate": "python-version"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": ["^roles/sdkman/defaults/main\\.yaml$"],
+      "matchStrings": ["java: \"(?<currentValue>[0-9]+\\.[0-9]+\\.[0-9]+)-tem\""],
+      "depNameTemplate": "java",
+      "datasourceTemplate": "java-version",
+      "extractVersionTemplate": "^(?<version>[0-9]+\\.[0-9]+\\.[0-9]+)"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": ["^roles/sdkman/defaults/main\\.yaml$"],
+      "matchStrings": ["maven: \"(?<currentValue>[0-9]+\\.[0-9]+\\.[0-9]+)\""],
+      "depNameTemplate": "maven",
+      "datasourceTemplate": "maven",
+      "packageNameTemplate": "org.apache.maven:maven"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": ["^roles/sdkman/defaults/main\\.yaml$"],
+      "matchStrings": ["gradle: \"(?<currentValue>[0-9]+\\.[0-9]+)\""],
+      "depNameTemplate": "gradle",
+      "datasourceTemplate": "gradle-version"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Remove Dependabot configuration
- Add Renovate with custom regex managers for version-pinned dependencies

## Configured updates
- GitHub Actions (via `config:recommended` preset)
- Ruby versions in `roles/rbenv/defaults/main.yaml`
- Python versions in `roles/pyenv/defaults/main.yaml`
- Java, Maven, Gradle versions in `roles/sdkman/defaults/main.yaml`

## Setup required
Install the [Renovate GitHub App](https://github.com/apps/renovate) on this repository.

## Test plan
- [ ] Install Renovate app
- [ ] Verify Renovate creates onboarding PR or starts scanning
- [ ] Confirm version update PRs are created for outdated dependencies