### PR TITLE
Only run apply-role for changed roles and their dependents

### DIFF
--- a/.github/workflows/roles.yml
+++ b/.github/workflows/roles.yml
@@ -14,16 +14,25 @@ jobs:
   find-roles:
     runs-on: ubuntu-latest
     outputs:
-      roles: ${{ steps.roles.outputs.roles }}
+      roles: ${{ steps.affected.outputs.roles }}
     steps:
       - uses: actions/checkout@v6
-      - id: roles
+        with:
+          fetch-depth: 0
+      - id: affected
         run: |
-          echo "roles=[$(ls roles | sed -E 's/(.*)/\"\1\"/g' | paste -sd , -)]" >> "$GITHUB_OUTPUT"
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            base_ref="origin/${{ github.base_ref }}"
+          else
+            base_ref="HEAD~1"
+          fi
+          roles=$(./scripts/find-affected-roles.sh "$base_ref")
+          echo "roles=$roles" >> "$GITHUB_OUTPUT"
   apply-role:
     runs-on: ${{ inputs.runs-on }}
     container: ${{ inputs.container }}
     needs: find-roles
+    if: ${{ needs.find-roles.outputs.roles != '[]' }}
     strategy:
       matrix:
         role: ${{ fromJson(needs.find-roles.outputs.roles) }}

--- a/scripts/find-affected-roles.sh
+++ b/scripts/find-affected-roles.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+set -euo pipefail
+
+base_ref="${1:-origin/main}"
+
+# Get changed roles from git diff
+changed_roles=$(git diff --name-only "$base_ref" -- roles/ | cut -d'/' -f2 | sort -u)
+
+if [[ -z "$changed_roles" ]]; then
+  echo "[]"
+  exit 0
+fi
+
+# Find roles that depend on a given role
+find_dependents() {
+  local role="$1"
+  grep -lF -- '- role: '"$role" roles/*/meta/main.yaml 2>/dev/null | while read -r meta; do
+    dirname "$meta" | xargs basename
+  done
+}
+
+# Collect affected roles (changed + dependents)
+affected=""
+for role in $changed_roles; do
+  affected="$affected $role"
+  for dependent in $(find_dependents "$role"); do
+    affected="$affected $dependent"
+  done
+done
+
+# Output as JSON array
+echo "$affected" | tr ' ' '\n' | grep -v '^$' | sort -u | jq -R . | jq -sc .


### PR DESCRIPTION
## Summary
- Add `scripts/find-affected-roles.sh` to detect changed roles using git diff
- Resolve reverse dependencies from `meta/main.yaml` files
- Skip `apply-role` job when no roles are affected

## How it works
1. `git diff` finds changed files in `roles/`
2. Script extracts role names from paths
3. For each changed role, finds roles that depend on it
4. Outputs deduplicated JSON array for matrix

## Test plan
- [ ] Verify workflow runs only affected roles on PR
- [ ] Verify workflow skips when no roles changed
- [ ] Verify dependent roles are included when dependency changes