### PR TITLE
Add 10 minute timeout for apply-role job

### DIFF
--- a/.github/workflows/roles.yml
+++ b/.github/workflows/roles.yml
@@ -33,6 +33,7 @@ jobs:
     container: ${{ inputs.container }}
     needs: find-roles
     if: ${{ needs.find-roles.outputs.roles != '[]' }}
+    timeout-minutes: 10
     strategy:
       matrix:
         role: ${{ fromJson(needs.find-roles.outputs.roles) }}


### PR DESCRIPTION
## Summary
- Add `timeout-minutes: 10` to the apply-role job
- Prevents jobs from running indefinitely if they hang

## Test plan
- [ ] Verify workflow still completes successfully within timeout