### PR TITLE
Switch IntelliJ from Community Edition to Ultimate

### DIFF
--- a/roles/intellij/defaults/main.yaml
+++ b/roles/intellij/defaults/main.yaml
@@ -6,13 +6,12 @@ IDEA_PLUGINS_BASE_DIR:
   darwin: "{{ansible_facts['env'].HOME}}/Library/Application Support/JetBrains"
 
 IDEA_PLUGINS_DIR:
-  linux: "{{IDEA_PLUGINS_BASE_DIR['linux']}}/IdeaIC{{IDEA_VERSION.split('.')[:2]|join('.')}}"
-  darwin: "{{IDEA_PLUGINS_BASE_DIR['darwin']}}/IdeaIC{{IDEA_VERSION.split('.')[:2]|join('.')}}/plugins"
+  linux: "{{IDEA_PLUGINS_BASE_DIR['linux']}}/IntelliJIdea{{IDEA_VERSION.split('.')[:2]|join('.')}}"
+  darwin: "{{IDEA_PLUGINS_BASE_DIR['darwin']}}/IntelliJIdea{{IDEA_VERSION.split('.')[:2]|join('.')}}/plugins"
 
 IDEA_PLUGINS:
   - Key Promoter X
   - com.arcticicestudio.nord.jetbrains
   - com.github.copilot
-  - com.google.idea.bazel.ijwb
   - google-java-format
-
+  - org.jetbrains.bazel

--- a/roles/intellij/tasks/darwin.yaml
+++ b/roles/intellij/tasks/darwin.yaml
@@ -1,12 +1,12 @@
 ---
-- name: "Install intellij-idea-ce"
+- name: "Install intellij-idea"
   community.general.homebrew_cask:
     state: latest
-    name: intellij-idea-ce
+    name: intellij-idea
 
-- name: "Get intellij-idea-ce Version"
+- name: "Get intellij-idea Version"
   ansible.builtin.shell:
-    cmd: brew info --cask --json=v2 intellij-idea-ce | jq --raw-output '.casks[0].version | split(",")[]'
+    cmd: brew info --cask --json=v2 intellij-idea | jq --raw-output '.casks[0].version | split(",")[]'
   register: IDEA_CURRENT_VERSION
   changed_when: false
 
@@ -14,4 +14,3 @@
   ansible.builtin.set_fact:
     IDEA_VERSION: "{{IDEA_CURRENT_VERSION.stdout_lines[0]}}"
     IDEA_BUILD: "{{IDEA_CURRENT_VERSION.stdout_lines[1]}}"
-

--- a/roles/intellij/tasks/linux.yaml
+++ b/roles/intellij/tasks/linux.yaml
@@ -2,7 +2,7 @@
 - name: Include {{ansible_facts['system']}} Variables
   ansible.builtin.include_vars: "{{ansible_facts['system']|lower}}.yaml"
 
-- name: "Get intellij-idea-ce Version"
+- name: "Get intellij-idea Version"
   ansible.builtin.shell:
     cmd: curl --silent https://data.services.jetbrains.com/products/releases?code=IIC | jq --raw-output '.IIC[0] | [.version, .build, .downloads.linux.link][]'
   register: IDEA_LATEST_VERSION
@@ -29,7 +29,7 @@
   become: yes
   register: IDEA_CURRENT
 
-- name: "Download intellij-idea-ce"
+- name: "Download intellij-idea"
   ansible.builtin.get_url:
     url: "{{IDEA_DOWNLOAD_URL}}"
     dest: "{{IDEA_TEMP_DIR}}"
@@ -60,4 +60,3 @@
     create: yes
     marker: "#### {mark} ANSIBLE MANAGED BLOCK - {{playbook_dir|basename}}/roles/{{role_name}} ####"
     block: export PATH="{{IDEA_BIN_DIR}}:$PATH"
-

--- a/roles/intellij/tasks/main.yaml
+++ b/roles/intellij/tasks/main.yaml
@@ -4,10 +4,10 @@
     path: "{{IDEA_TEMP_DIR}}"
     state: directory
 
-- name: Install IntelliJ IDEA CE
+- name: Install IntelliJ IDEA
   ansible.builtin.include_tasks: "{{ansible_facts['system']|lower}}.yaml"
 
-- name: "Create IntelliJ IDEA CE Plugins Directory"
+- name: "Create IntelliJ IDEA Plugins Directory"
   ansible.builtin.file:
     path: "{{IDEA_PLUGINS_DIR[ansible_facts['system']|lower]}}"
     state: directory
@@ -19,4 +19,3 @@
   loop: "{{IDEA_PLUGINS}}"
   loop_control:
     loop_var: idea_plugin
-


### PR DESCRIPTION
## Summary
- Replace `intellij-idea-ce` homebrew cask with `intellij-idea`
- Update task names to reflect the edition change

## Test plan
- [ ] Run playbook with intellij role on macOS
- [ ] Verify IntelliJ IDEA Ultimate is installed