### PR TITLE
Fix neovim symlink failure on fresh systems

### DIFF
--- a/roles/neovim/tasks/main.yaml
+++ b/roles/neovim/tasks/main.yaml
@@ -4,6 +4,11 @@
     state: latest
     name: neovim
 
+- name: "Create {{NEOVIM_CONFIG_DIR | dirname}}"
+  ansible.builtin.file:
+    path: "{{NEOVIM_CONFIG_DIR | dirname}}"
+    state: directory
+
 - name: "Symlink {{NEOVIM_CONFIG_DIR}}"
   ansible.builtin.file:
     src: "{{role_path}}/files/nvim"


### PR DESCRIPTION
## Summary
- Ensure `~/.config` parent directory exists before creating the nvim symlink
- Fixes CI failures on Debian and Fedora where `~/.config` doesn't exist

## Test plan
- [x] Verify Debian CI passes
- [x] Verify Fedora CI passes