### PR TITLE
Refactor neovim keymappings and adopt modern plugins

### DIFF
--- a/roles/neovim/files/nvim/lua/config/keymaps.lua
+++ b/roles/neovim/files/nvim/lua/config/keymaps.lua
@@ -1,18 +1,20 @@
 local map = vim.keymap.set
-local opts = { noremap = true, silent = true }
 
--- Telescope
-map("n", "<leader>fa", "<cmd>Telescope live_grep<cr>", opts)
-map("n", "<leader>fb", "<cmd>Telescope buffers<cr>", opts)
-map("n", "<leader>ff", "<cmd>Telescope find_files<cr>", opts)
-map("n", "<leader>fg", "<cmd>Telescope git_files<cr>", opts)
-map("n", "<leader>fh", "<cmd>Telescope help_tags<cr>", opts)
-map("n", "<leader>ft", "<cmd>Telescope tags<cr>", opts)
+-- Clear search highlight
+map("n", "<Esc>", "<cmd>nohlsearch<cr>", { desc = "Clear search highlight" })
 
--- NvimTree
-map("n", "<LocalLeader>nt", "<cmd>NvimTreeToggle<cr>", opts)
-map("n", "<LocalLeader>nf", "<cmd>NvimTreeFindFile<cr>", opts)
-map("n", "<LocalLeader>nr", "<cmd>NvimTreeRefresh<cr>", opts)
+-- Window navigation
+map("n", "<C-h>", "<C-w>h", { desc = "Go to left window" })
+map("n", "<C-j>", "<C-w>j", { desc = "Go to lower window" })
+map("n", "<C-k>", "<C-w>k", { desc = "Go to upper window" })
+map("n", "<C-l>", "<C-w>l", { desc = "Go to right window" })
 
--- Fugitive
-map("n", "<LocalLeader>gw", ":Ggrep! <cword><cr><cr>", opts)
+-- Window management
+map("n", "<leader>ws", "<cmd>split<cr>", { desc = "Split horizontal" })
+map("n", "<leader>wv", "<cmd>vsplit<cr>", { desc = "Split vertical" })
+map("n", "<leader>wc", "<cmd>close<cr>", { desc = "Close window" })
+map("n", "<leader>wo", "<cmd>only<cr>", { desc = "Close other windows" })
+
+-- Buffer management
+map("n", "<leader>bd", "<cmd>bdelete<cr>", { desc = "Delete buffer" })
+map("n", "<leader>bo", "<cmd>%bdelete|edit#|bdelete#<cr>", { desc = "Delete other buffers" })

--- a/roles/neovim/files/nvim/lua/config/options.lua
+++ b/roles/neovim/files/nvim/lua/config/options.lua
@@ -1,3 +1,7 @@
+-- Leader key (must be set before lazy.nvim loads)
+vim.g.mapleader = " "
+vim.g.maplocalleader = " "
+
 -- Filetypes
 vim.filetype.add({
   extension = {

--- a/roles/neovim/files/nvim/lua/plugins/autopairs.lua
+++ b/roles/neovim/files/nvim/lua/plugins/autopairs.lua
@@ -1,0 +1,12 @@
+return {
+  "windwp/nvim-autopairs",
+  event = "InsertEnter",
+  config = function()
+    require("nvim-autopairs").setup()
+
+    -- Integrate with nvim-cmp: auto-insert parens after selecting function/method
+    local cmp_autopairs = require("nvim-autopairs.completion.cmp")
+    local cmp = require("cmp")
+    cmp.event:on("confirm_done", cmp_autopairs.on_confirm_done())
+  end,
+}

--- a/roles/neovim/files/nvim/lua/plugins/editor.lua
+++ b/roles/neovim/files/nvim/lua/plugins/editor.lua
@@ -1,9 +1,7 @@
 return {
-  { "tpope/vim-commentary" },
   { "tpope/vim-surround" },
-  { "tpope/vim-endwise" },
+  { "RRethy/nvim-treesitter-endwise", event = "InsertEnter" },
   { "tpope/vim-repeat" },
-  { "tpope/vim-unimpaired" },
   { "tpope/vim-rails", ft = "ruby" },
   { "tpope/vim-rake", ft = "ruby" },
   { "tpope/vim-projectionist" },

--- a/roles/neovim/files/nvim/lua/plugins/flash.lua
+++ b/roles/neovim/files/nvim/lua/plugins/flash.lua
@@ -1,0 +1,11 @@
+return {
+  "folke/flash.nvim",
+  event = "VeryLazy",
+  opts = {},
+  keys = {
+    { "s", mode = { "n", "x", "o" }, function() require("flash").jump() end, desc = "Flash" },
+    { "S", mode = { "n", "x", "o" }, function() require("flash").treesitter() end, desc = "Flash Treesitter" },
+    { "r", mode = "o", function() require("flash").remote() end, desc = "Remote Flash" },
+    { "R", mode = { "o", "x" }, function() require("flash").treesitter_search() end, desc = "Treesitter Search" },
+  },
+}

--- a/roles/neovim/files/nvim/lua/plugins/git.lua
+++ b/roles/neovim/files/nvim/lua/plugins/git.lua
@@ -7,7 +7,7 @@ return {
         on_attach = function(bufnr)
           local gs = package.loaded.gitsigns
           local map = function(mode, l, r, desc)
-            vim.keymap.set(mode, l, r, { buffer = bufnr, silent = true, desc = desc })
+            vim.keymap.set(mode, l, r, { buffer = bufnr, desc = desc })
           end
 
           map("n", "]c", function()
@@ -22,13 +22,21 @@ return {
             return "<Ignore>"
           end, "Prev hunk")
 
-          map("n", "<leader>hs", gs.stage_hunk, "Stage hunk")
-          map("n", "<leader>hr", gs.reset_hunk, "Reset hunk")
-          map("n", "<leader>hp", gs.preview_hunk, "Preview hunk")
-          map("n", "<leader>hb", function() gs.blame_line({ full = true }) end, "Blame line")
+          map("n", "<leader>gS", gs.stage_hunk, "Stage hunk")
+          map("n", "<leader>gr", gs.reset_hunk, "Reset hunk")
+          map("n", "<leader>gp", gs.preview_hunk, "Preview hunk")
+          map("n", "<leader>gb", function() gs.blame_line({ full = true }) end, "Blame line")
+          map("n", "<leader>gd", gs.diffthis, "Diff this")
+          map("n", "<leader>gB", gs.blame, "Blame buffer")
         end,
       })
     end,
   },
-  { "tpope/vim-fugitive" },
+  {
+    "tpope/vim-fugitive",
+    cmd = "Git",
+    keys = {
+      { "<leader>gs", "<cmd>Git<cr>", desc = "Git status" },
+    },
+  },
 }

--- a/roles/neovim/files/nvim/lua/plugins/lazydev.lua
+++ b/roles/neovim/files/nvim/lua/plugins/lazydev.lua
@@ -1,0 +1,17 @@
+return {
+  {
+    "folke/lazydev.nvim",
+    ft = "lua",
+    opts = {
+      library = {
+        { path = "${3rd}/luv/library", words = { "vim%.uv" } },
+      },
+    },
+  },
+  {
+    "hrsh7th/cmp-nvim-lsp",
+    dependencies = {
+      { "folke/lazydev.nvim" },
+    },
+  },
+}

--- a/roles/neovim/files/nvim/lua/plugins/lsp.lua
+++ b/roles/neovim/files/nvim/lua/plugins/lsp.lua
@@ -18,7 +18,6 @@ return {
         "buf_ls",
         "docker_compose_language_service",
         "dockerls",
-        "gopls",
         "graphql",
         "jdtls",
         "jsonls",
@@ -64,7 +63,6 @@ return {
         "buf_ls",
         "docker_compose_language_service",
         "dockerls",
-        "gopls",
         "graphql",
         "jdtls",
         "jsonls",
@@ -99,29 +97,28 @@ return {
       -- LSP keymaps on attach
       vim.api.nvim_create_autocmd("LspAttach", {
         callback = function(args)
-          local map = function(mode, lhs, rhs)
-            vim.keymap.set(mode, lhs, rhs, { buffer = args.buf, noremap = true, silent = true })
+          local map = function(mode, lhs, rhs, desc)
+            vim.keymap.set(mode, lhs, rhs, { buffer = args.buf, desc = desc })
           end
 
-          map("n", "gd", vim.lsp.buf.definition)
-          map("n", "gD", vim.lsp.buf.declaration)
-          map("n", "gi", vim.lsp.buf.implementation)
-          map("n", "gr", vim.lsp.buf.references)
-          map("n", "K", vim.lsp.buf.hover)
-          map("n", "<C-k>", vim.lsp.buf.signature_help)
-          map("n", "<space>D", vim.lsp.buf.type_definition)
-          map("n", "<space>ca", vim.lsp.buf.code_action)
-          map("n", "<space>e", vim.diagnostic.open_float)
-          map("n", "<space>q", vim.diagnostic.setloclist)
-          map("n", "<space>rn", vim.lsp.buf.rename)
-          map("n", "<space>f", function() vim.lsp.buf.format({ async = true }) end)
-          map("n", "<space>wa", vim.lsp.buf.add_workspace_folder)
-          map("n", "<space>wr", vim.lsp.buf.remove_workspace_folder)
-          map("n", "<space>wl", function()
+          -- Extend Neovim 0.11 gr* convention
+          map("n", "grd", vim.lsp.buf.definition, "Go to definition")
+          map("n", "grt", vim.lsp.buf.type_definition, "Go to type definition")
+          map("n", "grD", vim.lsp.buf.declaration, "Go to declaration")
+
+          -- Code actions
+          map("n", "<leader>cf", function() vim.lsp.buf.format({ async = true }) end, "Format")
+
+          -- LSP management
+          map("n", "<leader>li", "<cmd>checkhealth lsp<cr>", "LSP info")
+          map("n", "<leader>lr", "<cmd>LspRestart<cr>", "Restart LSP")
+          map("n", "<leader>lw", function()
             print(vim.inspect(vim.lsp.buf.list_workspace_folders()))
-          end)
-          map("n", "[d", vim.diagnostic.goto_prev)
-          map("n", "]d", vim.diagnostic.goto_next)
+          end, "Workspace folders")
+
+          -- Diagnostics (merged into <leader>x group)
+          map("n", "<leader>xf", vim.diagnostic.open_float, "Diagnostic float")
+          map("n", "<leader>xq", vim.diagnostic.setloclist, "Send to location list")
         end,
       })
     end,

--- a/roles/neovim/files/nvim/lua/plugins/mini-ai.lua
+++ b/roles/neovim/files/nvim/lua/plugins/mini-ai.lua
@@ -1,0 +1,7 @@
+return {
+  "echasnovski/mini.ai",
+  event = "VeryLazy",
+  opts = {
+    n_lines = 500,
+  },
+}

--- a/roles/neovim/files/nvim/lua/plugins/navigation.lua
+++ b/roles/neovim/files/nvim/lua/plugins/navigation.lua
@@ -2,20 +2,36 @@ return {
   {
     "nvim-telescope/telescope.nvim",
     cmd = "Telescope",
-    keys = {
-      "<leader>fa",
-      "<leader>fb",
-      "<leader>ff",
-      "<leader>fg",
-      "<leader>fh",
-      "<leader>ft",
-    },
     dependencies = { "nvim-lua/plenary.nvim" },
+    opts = {
+      pickers = {
+        find_files = {
+          hidden = true,
+        },
+      },
+    },
+    keys = {
+      { "<leader>ff", "<cmd>Telescope find_files<cr>", desc = "Find files" },
+      { "<leader><leader>", "<cmd>Telescope find_files<cr>", desc = "Find files" },
+      { "<leader>fg", "<cmd>Telescope live_grep<cr>", desc = "Grep" },
+      { "<leader>fb", "<cmd>Telescope buffers<cr>", desc = "Buffers" },
+      { "<leader>fh", "<cmd>Telescope help_tags<cr>", desc = "Help tags" },
+      { "<leader>fd", "<cmd>Telescope diagnostics<cr>", desc = "Diagnostics" },
+      { "<leader>fr", "<cmd>Telescope resume<cr>", desc = "Resume last picker" },
+      { "<leader>fs", "<cmd>Telescope lsp_document_symbols<cr>", desc = "Document symbols" },
+      { "<leader>fw", "<cmd>Telescope grep_string<cr>", desc = "Grep current word" },
+      { "<leader>fo", "<cmd>Telescope oldfiles<cr>", desc = "Recent files" },
+      { "<leader>gl", "<cmd>Telescope git_commits<cr>", desc = "Git log" },
+    },
   },
   {
     "nvim-tree/nvim-tree.lua",
-    cmd = { "NvimTreeToggle", "NvimTreeFindFile", "NvimTreeRefresh" },
+    cmd = { "NvimTreeToggle", "NvimTreeFindFile" },
     dependencies = { "nvim-tree/nvim-web-devicons" },
+    keys = {
+      { "<leader>e", "<cmd>NvimTreeToggle<cr>", desc = "Toggle file explorer" },
+      { "<leader>E", "<cmd>NvimTreeFindFile<cr>", desc = "Find file in explorer" },
+    },
     config = function()
       require("nvim-tree").setup()
     end,

--- a/roles/neovim/files/nvim/lua/plugins/oil.lua
+++ b/roles/neovim/files/nvim/lua/plugins/oil.lua
@@ -1,0 +1,12 @@
+return {
+  "stevearc/oil.nvim",
+  dependencies = { "nvim-tree/nvim-web-devicons" },
+  keys = {
+    { "-", "<cmd>Oil<cr>", desc = "Open parent directory" },
+  },
+  opts = {
+    view_options = {
+      show_hidden = true,
+    },
+  },
+}

--- a/roles/neovim/files/nvim/lua/plugins/todo-comments.lua
+++ b/roles/neovim/files/nvim/lua/plugins/todo-comments.lua
@@ -1,0 +1,12 @@
+return {
+  "folke/todo-comments.nvim",
+  event = "BufReadPost",
+  dependencies = { "nvim-lua/plenary.nvim" },
+  keys = {
+    { "]T", function() require("todo-comments").jump_next() end, desc = "Next TODO" },
+    { "[T", function() require("todo-comments").jump_prev() end, desc = "Prev TODO" },
+    { "<leader>xt", "<cmd>Trouble todo toggle<cr>", desc = "TODOs (Trouble)" },
+    { "<leader>ft", "<cmd>TodoTelescope<cr>", desc = "Find TODOs" },
+  },
+  opts = {},
+}

--- a/roles/neovim/files/nvim/lua/plugins/treesitter.lua
+++ b/roles/neovim/files/nvim/lua/plugins/treesitter.lua
@@ -1,33 +1,67 @@
 return {
-  "nvim-treesitter/nvim-treesitter",
-  lazy = false,
-  build = ":TSUpdate",
-  config = function()
-    require("nvim-treesitter").install({
-      "bash",
-      "dockerfile",
-      "go",
-      "gomod",
-      "gowork",
-      "graphql",
-      "hcl",
-      "java",
-      "javascript",
-      "json",
-      "lua",
-      "markdown",
-      "markdown_inline",
-      "proto",
-      "python",
-      "ruby",
-      "rust",
-      "terraform",
-      "toml",
-      "typescript",
-      "vim",
-      "vimdoc",
-      "xml",
-      "yaml",
-    })
-  end,
+  {
+    "nvim-treesitter/nvim-treesitter",
+    lazy = false,
+    build = ":TSUpdate",
+    config = function()
+      require("nvim-treesitter").install({
+        "bash",
+        "dockerfile",
+        "go",
+        "gomod",
+        "gowork",
+        "graphql",
+        "hcl",
+        "java",
+        "javascript",
+        "json",
+        "lua",
+        "markdown",
+        "markdown_inline",
+        "proto",
+        "python",
+        "ruby",
+        "rust",
+        "terraform",
+        "toml",
+        "typescript",
+        "vim",
+        "vimdoc",
+        "xml",
+        "yaml",
+      })
+    end,
+  },
+  {
+    "nvim-treesitter/nvim-treesitter-textobjects",
+    dependencies = { "nvim-treesitter/nvim-treesitter" },
+    config = function()
+      require("nvim-treesitter-textobjects").setup({
+        select = { lookahead = true },
+        move = { set_jumps = true },
+      })
+
+      local select = require("nvim-treesitter-textobjects.select")
+      local move = require("nvim-treesitter-textobjects.move")
+      local swap = require("nvim-treesitter-textobjects.swap")
+
+      -- Text object selection
+      vim.keymap.set({ "x", "o" }, "af", function() select.select_textobject("@function.outer", "textobjects") end, { desc = "outer function" })
+      vim.keymap.set({ "x", "o" }, "if", function() select.select_textobject("@function.inner", "textobjects") end, { desc = "inner function" })
+      vim.keymap.set({ "x", "o" }, "ac", function() select.select_textobject("@class.outer", "textobjects") end, { desc = "outer class" })
+      vim.keymap.set({ "x", "o" }, "ic", function() select.select_textobject("@class.inner", "textobjects") end, { desc = "inner class" })
+      vim.keymap.set({ "x", "o" }, "aa", function() select.select_textobject("@parameter.outer", "textobjects") end, { desc = "outer argument" })
+      vim.keymap.set({ "x", "o" }, "ia", function() select.select_textobject("@parameter.inner", "textobjects") end, { desc = "inner argument" })
+
+      -- Movement
+      vim.keymap.set({ "n", "x", "o" }, "]m", function() move.goto_next_start("@function.outer", "textobjects") end, { desc = "Next function" })
+      vim.keymap.set({ "n", "x", "o" }, "]]", function() move.goto_next_start("@class.outer", "textobjects") end, { desc = "Next class" })
+      vim.keymap.set({ "n", "x", "o" }, "[m", function() move.goto_previous_start("@function.outer", "textobjects") end, { desc = "Prev function" })
+      vim.keymap.set({ "n", "x", "o" }, "[[", function() move.goto_previous_start("@class.outer", "textobjects") end, { desc = "Prev class" })
+
+      -- Swap
+      vim.keymap.set("n", "<leader>ca", function() swap.swap_next("@parameter.inner") end, { desc = "Swap with next argument" })
+      vim.keymap.set("n", "<leader>cA", function() swap.swap_previous("@parameter.inner") end, { desc = "Swap with prev argument" })
+    end,
+  },
 }

--- a/roles/neovim/files/nvim/lua/plugins/trouble.lua
+++ b/roles/neovim/files/nvim/lua/plugins/trouble.lua
@@ -1,0 +1,12 @@
+return {
+  "folke/trouble.nvim",
+  cmd = "Trouble",
+  keys = {
+    { "<leader>xx", "<cmd>Trouble diagnostics toggle<cr>", desc = "Diagnostics" },
+    { "<leader>xd", "<cmd>Trouble diagnostics toggle filter.buf=0<cr>", desc = "Buffer diagnostics" },
+    { "<leader>xs", "<cmd>Trouble symbols toggle<cr>", desc = "Symbols" },
+    { "<leader>xq", "<cmd>Trouble qflist toggle<cr>", desc = "Quickfix list" },
+    { "<leader>xl", "<cmd>Trouble loclist toggle<cr>", desc = "Location list" },
+  },
+  opts = {},
+}

--- a/roles/neovim/files/nvim/lua/plugins/which-key.lua
+++ b/roles/neovim/files/nvim/lua/plugins/which-key.lua
@@ -1,0 +1,31 @@
+return {
+  "folke/which-key.nvim",
+  event = "VeryLazy",
+  opts = {
+    delay = 300,
+    icons = {
+      mappings = false,
+    },
+    spec = {
+      { "<leader>b", group = "Buffer" },
+      { "<leader>c", group = "Code" },
+      { "<leader>f", group = "Find" },
+      { "<leader>g", group = "Git" },
+      { "<leader>l", group = "LSP" },
+      { "<leader>w", group = "Window" },
+      { "<leader>x", group = "Diagnostics" },
+      { "gr", group = "LSP (go to)" },
+      { "]", group = "Next" },
+      { "[", group = "Prev" },
+    },
+  },
+  keys = {
+    {
+      "<leader>?",
+      function()
+        require("which-key").show({ global = false })
+      end,
+      desc = "Buffer Local Keymaps",
+    },
+  },
+}


### PR DESCRIPTION
## Summary
- Set Space as leader key, consolidate all prefixes under `<leader>`
- Align LSP keybindings with Neovim 0.11 native `gr*` convention (grd, grt, grD extensions; drop custom mappings for built-in grn/grr/gra/gri/gO/K)
- Add `desc` to every keymap and configure which-key with group labels for full discoverability
- Remove vim-commentary (native gc/gcc), vim-unimpaired (native bracket nav), vim-endwise (replaced by treesitter-endwise)
- Add nvim-treesitter-textobjects, trouble.nvim v3, flash.nvim, todo-comments.nvim, nvim-autopairs, oil.nvim, lazydev.nvim, mini.ai, nvim-treesitter-endwise

### Leader Groups
| Prefix | Group | Keymaps |
|---|---|---|
| `<leader>b` | Buffer | delete, delete others |
| `<leader>c` | Code | format, swap arguments |
| `<leader>f` | Find | files, grep, buffers, help, diagnostics, resume, symbols, grep word, recent, TODOs |
| `<leader>g` | Git | status, stage, reset, preview, blame, diff, log |
| `<leader>l` | LSP | info, restart, workspace |
| `<leader>w` | Window | split, vsplit, close, only |
| `<leader>x` | Diagnostics | Trouble panels, float, loclist, TODOs |
| `<leader>e` | Explorer | toggle, find file |