### PR TITLE
Add tmux bell and passthrough settings for terminal notifications

### DIFF
--- a/roles/tmux/files/tmux.conf
+++ b/roles/tmux/files/tmux.conf
@@ -9,14 +9,19 @@ set -g @plugin 'tmux-plugins/tmux-resurrect'
 set -g @plugin 'tmux-plugins/tmux-sensible'
 set -g @plugin 'tmux-plugins/tpm'
 
+set -g allow-passthrough all
+set -g automatic-rename on
+set -g automatic-rename-format '#{b:pane_current_path}'
 set -g base-index 1
+set -g bell-action any
 set -g default-command "$0"
 set -g mode-keys vi
+set -g monitor-bell on
 set -g pane-active-border-style fg=magenta
 set -g pane-border-style fg=brightblue
 set -g renumber-windows on
-set -g automatic-rename on
-set -g automatic-rename-format '#{b:pane_current_path}'
 set -g terminal-overrides ",$TERM:RGB"
+set -g update-environment "TERM_PROGRAM TERM_PROGRAM_VERSION ITERM_SESSION_ID"
+set -g visual-bell off
 
 run '~/.tmux/plugins/tpm/tpm'


### PR DESCRIPTION
## Summary
- Enable `allow-passthrough all` so OSC escape sequences (e.g., terminal notifications) propagate through tmux to the outer terminal
- Configure bell settings (`bell-action any`, `monitor-bell on`, `visual-bell off`) to forward bell signals across tmux windows
- Add `update-environment` to preserve `TERM_PROGRAM` and related vars for outer terminal detection
- Alphabetize tmux options for consistency