### PR TITLE
Add peon-ping Homebrew role

### DIFF
--- a/roles/peon-ping/tasks/main.yaml
+++ b/roles/peon-ping/tasks/main.yaml
@@ -1,0 +1,16 @@
+---
+- name: "Tap peonping"
+  community.general.homebrew_tap:
+    name: peonping/tap
+
+- name: "Install peon-ping"
+  community.general.homebrew:
+    state: latest
+    name: peon-ping
+
+- name: "Run peon-ping-setup"
+  ansible.builtin.shell: peon-ping-setup
+  args:
+    creates: "{{ansible_facts['env'].HOME}}/.claude/hooks/peon-ping/peon.sh"
+    executable: /bin/bash
+  when: "(ansible_facts['env'].HOME + '/.claude') is directory"


### PR DESCRIPTION
## Summary
- Adds Ansible role to install peon-ping via Homebrew (taps `peonping/tap`)
- Runs `peon-ping-setup` post-install, skipped if already configured