### PR TITLE
Update color schemes to Catppuccin Mocha

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -89,7 +89,7 @@
       ],
       "depNameTemplate": "{{{packageName}}}",
       "datasourceTemplate": "git-refs",
-      "currentValueTemplate": "develop"
+      "currentValueTemplate": "main"
     },
     {
       "customType": "regex",

--- a/roles/colorscheme/tasks/gnome-terminal.yaml
+++ b/roles/colorscheme/tasks/gnome-terminal.yaml
@@ -1,17 +1,17 @@
 ---
-- name: "Git Clone arcticicestudio/nord-gnome-terminal"
+- name: "Git Clone catppuccin/gnome-terminal"
   ansible.builtin.git:
-    repo: https://github.com/arcticicestudio/nord-gnome-terminal.git
-    dest: "{{ ansible_facts['env'].HOME }}/.nord-gnome-terminal"
-    version: c15b85a5389cf3bfd37fe409e915a88ecf902640
-  register: colorscheme_nord_gnome_terminal_repo
+    repo: https://github.com/catppuccin/gnome-terminal.git
+    dest: "{{ ansible_facts['env'].HOME }}/.catppuccin-gnome-terminal"
+    version: 75e57457f58a34baf2ec7d9e13556ca53d598395
+  register: colorscheme_catppuccin_gnome_terminal_repo
 
-- name: "Install Nord Color Scheme For Gnome Terminal" # noqa: no-handler
+- name: "Install Catppuccin Color Scheme For Gnome Terminal" # noqa: no-handler
   ansible.builtin.command:
-    cmd: "dbus-run-session ./nord.sh"
-    chdir: "{{ ansible_facts['env'].HOME }}/.nord-gnome-terminal/src"
+    cmd: "dbus-run-session python3 install.py"
+    chdir: "{{ ansible_facts['env'].HOME }}/.catppuccin-gnome-terminal"
   changed_when: true
-  when: colorscheme_nord_gnome_terminal_repo.changed
+  when: colorscheme_catppuccin_gnome_terminal_repo.changed
 
 - name: "List Gnome Terminal Profile Ids"
   ansible.builtin.shell:
@@ -47,6 +47,6 @@
 
 - name: "Set Gnome Terminal Default Profile Id"
   ansible.builtin.command:
-    cmd: "gsettings set org.gnome.Terminal.ProfilesList default '{{ colorscheme_gnome_terminal_profile_mappings['Nord'] }}'"
+    cmd: "gsettings set org.gnome.Terminal.ProfilesList default '{{ colorscheme_gnome_terminal_profile_mappings['Catppuccin Mocha'] }}'"
   changed_when: true
-  when: colorscheme_gnome_terminal_default_profile_id.stdout != colorscheme_gnome_terminal_profile_mappings['Nord']
+  when: colorscheme_gnome_terminal_default_profile_id.stdout != colorscheme_gnome_terminal_profile_mappings['Catppuccin Mocha']

--- a/roles/colorscheme/tasks/iterm2-app.yaml
+++ b/roles/colorscheme/tasks/iterm2-app.yaml
@@ -1,21 +1,13 @@
 ---
-- name: "Git Clone arcticicestudio/nord-iterm2"
+- name: "Git Clone catppuccin/iterm"
   ansible.builtin.git:
-    repo: https://github.com/arcticicestudio/nord-iterm2.git
-    dest: "{{ ansible_facts['env'].HOME }}/.nord-iterm2"
-    version: 233a2462e04e07a9676386a52dad0c2ff6666d72
-  register: colorscheme_nord_iterm2_repo
+    repo: https://github.com/catppuccin/iterm.git
+    dest: "{{ ansible_facts['env'].HOME }}/.catppuccin-iterm"
+    version: b2936a6e55270fcc55421b1bb7d5fd194a489591
+  register: colorscheme_catppuccin_iterm_repo
 
-- name: "Set Nord Color Scheme For Default iterm2 Profile" # noqa: no-handler
-  ansible.builtin.shell:
-    cmd: >-
-      /usr/libexec/PlistBuddy
-      -c "Add :'New Bookmarks' array"
-      -c "Add :'New Bookmarks':0 dict"
-      {{ colorscheme_iterm2_plist }} 2>/dev/null;
-      /usr/libexec/PlistBuddy
-      -c "Merge '{{ ansible_facts['env'].HOME }}/.nord-iterm2/src/xml/Nord.itermcolors' :'New Bookmarks':0"
-      {{ colorscheme_iterm2_plist }}
-    executable: /bin/bash
+- name: "Import Catppuccin Mocha Color Scheme into iTerm2" # noqa: no-handler
+  ansible.builtin.command:
+    cmd: open "{{ ansible_facts['env'].HOME }}/.catppuccin-iterm/colors/catppuccin-mocha.itermcolors"
   changed_when: true
-  when: colorscheme_nord_iterm2_repo.changed
+  when: colorscheme_catppuccin_iterm_repo.changed

--- a/roles/gitconfig/files/gitconfig
+++ b/roles/gitconfig/files/gitconfig
@@ -14,7 +14,7 @@
   dark = true
   line-numbers = true
   navigate = true
-  syntax-theme = Nord
+  syntax-theme = Catppuccin Mocha
 [diff]
   colorMoved = default
 [init]

--- a/roles/intellij/defaults/main.yaml
+++ b/roles/intellij/defaults/main.yaml
@@ -12,7 +12,7 @@ intellij_idea_plugins_dir:
 intellij_idea_plugins:
   - Key Promoter X
   - com.anthropic.code.plugin
-  - com.arcticicestudio.nord.jetbrains
+  - com.github.catppuccin.jetbrains
   - com.github.copilot
   - google-java-format
   - org.jetbrains.bazel

--- a/roles/neovim/files/nvim/lua/plugins/colorscheme.lua
+++ b/roles/neovim/files/nvim/lua/plugins/colorscheme.lua
@@ -1,9 +1,8 @@
 return {
-  "nordtheme/vim",
-  name = "nord",
-  lazy = false,
+  "catppuccin/nvim",
+  name = "catppuccin",
   priority = 1000,
   config = function()
-    vim.cmd.colorscheme("nord")
+    vim.cmd.colorscheme("catppuccin-nvim")
   end,
 }

--- a/roles/neovim/files/nvim/lua/plugins/statusline.lua
+++ b/roles/neovim/files/nvim/lua/plugins/statusline.lua
@@ -4,7 +4,7 @@ return {
   config = function()
     require("lualine").setup({
       options = {
-        theme = "nord",
+        theme = "catppuccin-nvim",
       },
     })
   end,

--- a/roles/rustup/files/cargo.sh
+++ b/roles/rustup/files/cargo.sh
@@ -1,3 +1,3 @@
 export PATH="$HOME/.cargo/bin:$PATH"
-export BAT_THEME='Nord'
+export BAT_THEME='Catppuccin Mocha'
 export PAGER='bat'

--- a/roles/tmux/files/tmux.conf
+++ b/roles/tmux/files/tmux.conf
@@ -20,7 +20,7 @@ set -g monitor-bell on
 set -g pane-active-border-style fg=magenta
 set -g pane-border-style fg=brightblue
 set -g renumber-windows on
-set -g terminal-overrides ",$TERM:RGB"
+set -as terminal-features ",xterm-256color:RGB"
 set -g update-environment "TERM_PROGRAM TERM_PROGRAM_VERSION ITERM_SESSION_ID"
 set -g visual-bell off
 


### PR DESCRIPTION
## Summary
- Switch terminal color scheme (iTerm2, GNOME Terminal) from Nord to Catppuccin Mocha
- Switch Neovim colorscheme and lualine theme from Nord to Catppuccin
- Switch IntelliJ theme plugin from Nord to Catppuccin
- Switch bat/delta syntax theme from Nord to Catppuccin Mocha
- Use `set -as terminal-features` instead of `terminal-overrides` in tmux for RGB support
- Pin colorscheme git repos and update Renovate branch target from `develop` to `main`